### PR TITLE
Fix local-stack Console-Gateway connectivity and Bitnami images

### DIFF
--- a/local-stack/01-start.sh
+++ b/local-stack/01-start.sh
@@ -49,7 +49,6 @@ waitRollout cdk-deps sts/kafka-controller
 
 # generate truststore for Schema registry using Kafka certificates
 generate_schema_registry_jks_truststore
-#separte because bitnami schema-registry expect ssl.truststore.jks file that we can't create using cert-manager
 kubectl apply -f ${STACK_DIR}/03-components/schema-registry.yaml
 
 echo

--- a/local-stack/k3d-stack/03-components/kafka.yaml
+++ b/local-stack/k3d-stack/03-components/kafka.yaml
@@ -16,8 +16,13 @@ spec:
   version: 32.1.2
   targetNamespace: cdk-deps
   set:
+    global.security.allowInsecureImages: "true"
     clusterId: "cdk"
+    image.repository: "bitnamilegacy/kafka"
     image.debug: "false"
+    defaultInitContainers.volumePermissions.image.repository: "bitnamilegacy/os-shell"
+    defaultInitContainers.autoDiscovery.image.repository: "bitnamilegacy/os-shell"
+    metrics.jmx.image.repository: "bitnamilegacy/jmx-exporter"
     listeners.client.port: "9092"
     listeners.client.protocol: "SASL_SSL"
     listeners.external.protocol: "SASL_SSL"

--- a/local-stack/k3d-stack/03-components/monitoring.yaml
+++ b/local-stack/k3d-stack/03-components/monitoring.yaml
@@ -34,6 +34,9 @@ spec:
   targetNamespace: monitoring
   createNamespace: true
   set:
+    global.security.allowInsecureImages: "true"
     operator.namespaceScope: "false"
     operator.watchNamespace: ""
+    operator.image.repository: "bitnamilegacy/grafana-operator"
     grafana.enabled: "false"
+    grafana.image.repository: "bitnamilegacy/grafana"

--- a/local-stack/k3d-stack/03-components/postgresql.yaml
+++ b/local-stack/k3d-stack/03-components/postgresql.yaml
@@ -16,6 +16,10 @@ spec:
   set:
     global.postgresql.auth.database: conduktor
     global.postgresql.auth.postgresPassword: conduktor
+    global.security.allowInsecureImages: "true"
+    image.repository: "bitnamilegacy/postgresql"
+    volumePermissions.image.repository: "bitnamilegacy/os-shell"
+    metrics.image.repository: "bitnamilegacy/postgres-exporter"	
     auth.postgresPassword: conduktor
     primary.persistence.size: 1Gi
     volumePermissions.enabled: "true"
@@ -38,6 +42,10 @@ spec:
   set:
     global.postgresql.auth.database: conduktor
     global.postgresql.auth.postgresPassword: conduktor
+    global.security.allowInsecureImages: "true"
+    image.repository: "bitnamilegacy/postgresql"
+    volumePermissions.image.repository: "bitnamilegacy/os-shell"
+    metrics.image.repository: "bitnamilegacy/postgres-exporter"	
     auth.postgresPassword: conduktor
     primary.persistence.size: 1Gi
     volumePermissions.enabled: "true"

--- a/local-stack/provisioning/main.tf
+++ b/local-stack/provisioning/main.tf
@@ -63,7 +63,7 @@ module "clusters" {
         password = var.schema_registry_password
       }
       gateway = {
-        baseUrl       = var.gateway_base_url
+        baseUrl       = "${var.gateway_base_url}:8888"
         adminUser     = var.gateway_admin_user
         adminPassword = var.gateway_admin_password
       }
@@ -85,7 +85,7 @@ module "clusters" {
         password = var.schema_registry_password
       }
       gateway = {
-        baseUrl       = var.gateway_base_url
+        baseUrl       = "${var.gateway_base_url}:8888"
         adminUser     = var.gateway_admin_user
         adminPassword = var.gateway_admin_password
       }


### PR DESCRIPTION
- Migrate to Bitnami charts used in local stack to use bitnamilegacy images because of [Bitnami catalog changes](https://github.com/bitnami/containers/issues/83267)
- Fix Console <> Gateway API configuration by adding missing port on cluster configuration