### PR TITLE
Add email scope to keycloak realm json

### DIFF
--- a/local-stack/k3d-stack/03-components/keycloak.yaml
+++ b/local-stack/k3d-stack/03-components/keycloak.yaml
@@ -288,7 +288,8 @@ data:
           "nodeReRegistrationTimeout": -1,
           "defaultClientScopes": [
             "profile",
-            "groups"
+            "groups",
+            "email"
           ],
           "optionalClientScopes": [
             "address",
@@ -299,6 +300,35 @@ data:
         }
       ],
       "clientScopes": [
+        {
+          "id": "44ab586a-b66c-41b0-9b18-d22c5fe28e9f",
+          "name": "email",
+          "description": "",
+          "protocol": "openid-connect",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true",
+            "gui.order": "",
+            "consent.screen.text": ""
+          },
+          "protocolMappers": [
+            {
+              "id": "7a571f1a-2dbb-456c-a79a-c108e822f56e",
+              "name": "kafka-audience",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-audience-mapper",
+              "consentRequired": false,
+              "config": {
+                "id.token.claim": "false",
+                "lightweight.claim": "false",
+                "introspection.token.claim": "true",
+                "access.token.claim": "true",
+                "included.custom.audience": "account",
+                "userinfo.token.claim": "false"
+              }
+            }
+          ]
+        },    
         {
           "id": "13aedb04-8483-4373-ad59-83f321674951",
           "name": "groups",
@@ -550,7 +580,8 @@ data:
       ],
       "defaultDefaultClientScopes": [
         "profile",
-        "groups"
+        "groups",
+        "email"
       ],
       "browserSecurityHeaders": {
         "contentSecurityPolicyReportOnly": "",


### PR DESCRIPTION
The example of "kafka-topics --list --command-config client.properties" in the README file does not really work because client.properties expects the token to have "email" scope. And the keycloak realm configuration is missing "email" scope configuration. 

This PR adds the "email" scope to the keycloak realm configuration and also "audience" claim.