### PR TITLE
Force requested cpu to string in local-stack values

### DIFF
--- a/local-stack/console-values.yaml
+++ b/local-stack/console-values.yaml
@@ -51,7 +51,7 @@ platform:
   resources:
     # reduce resource requests for example purpose.
     requests:
-      cpu: 0.5
+      cpu: 500m
       memory: 1Gi
   extraEnvVars:
     - name: CDK_ROOT_LOG_FORMAT
@@ -131,7 +131,7 @@ platformCortex:
   resources:
     # reduce resource requests for example purpose.
     requests:
-      cpu: 0.5
+      cpu: 500m
       memory: 0.5Gi
 
   containerSecurityContext:

--- a/local-stack/gateway-values.yaml
+++ b/local-stack/gateway-values.yaml
@@ -3,7 +3,7 @@ gateway:
   resources:
     # reduce resource requests for example purpose.
     requests:
-      cpu: 0.5
+      cpu: 500m
       memory: 1Gi
 
   secretRef: "gateway-secrets"


### PR DESCRIPTION
To avoid error "Invalid type. Expected: string, given: number" on `resources.requests.cpu` value, this PR force value to string using "millicpu/millicores" syntax