### PR TITLE
refactor for multiple listeners

### DIFF
--- a/local-stack/01-start.sh
+++ b/local-stack/01-start.sh
@@ -61,8 +61,9 @@ echo "05 - Update KubeDNS config for Gateway SNI routing"
 kubectl apply -f ${STACK_DIR}/05-coredns-custom.yaml
 kubectl -n kube-system delete pod -l k8s-app=kube-dns
 
-# Extract and package all certificates into a JKS truststore for Conduktor Gateway and Conduktor Console
-generate_jks_truststore
+# The bundle-truststore secret is generated declaratively by the trust-manager Bundle defined in
+# k3d-stack/02-infra-crds.yaml, so there is nothing to build here - just wait for it to be synced.
+waitSecretCreated conduktor bundle-truststore
 
-# Download the truststore to the local machine
+# Download the truststore to the local machine (used by client.properties)
 kubectl get secret bundle-truststore -n conduktor -o jsonpath='{.data.truststore\.jks}' | base64 --decode > $SCRIPT_DIR/truststore.jks

--- a/local-stack/03-init-conduktor-platform.sh
+++ b/local-stack/03-init-conduktor-platform.sh
@@ -2,6 +2,9 @@
 
 set -E
 
+# Unset any existing API keys
+unset CDK_API_KEY
+
 SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 TERRAFORM_DIR=${SCRIPT_DIR}/provisioning
 

--- a/local-stack/client.properties
+++ b/local-stack/client.properties
@@ -3,11 +3,9 @@ security.protocol=SASL_SSL
 sasl.mechanism=OAUTHBEARER
 
 # SASL OAUTH configuration
-sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required \
-    clientId="app-1" \
-    clientSecret="app-1-secret" \
-    scope="email";
-
+sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;
+sasl.oauthbearer.client.credentials.client.id=app-1
+sasl.oauthbearer.client.credentials.client.secret=app-1-secret
 sasl.oauthbearer.token.endpoint.url=https://oidc.localhost/realms/conduktor-realm/protocol/openid-connect/token
 sasl.login.callback.handler.class=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler
 # Your IdP may require configuring sub claim name. If so, make sure it matches the value of GATEWAY_OAUTH_SUB_CLAIM_NAME in gateway-values.yaml.

--- a/local-stack/console-values.yaml
+++ b/local-stack/console-values.yaml
@@ -141,7 +141,6 @@ platformCortex:
     privileged: false
     runAsUser: 10001
     runAsGroup: 0
-    fsGroup: 0
 
 
 # TODO enable TLS on S3 endpoint

--- a/local-stack/gateway-secrets.yaml
+++ b/local-stack/gateway-secrets.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: conduktor
 type: Opaque
 stringData: # use stringData to avoid base64 encoding for demo. Don't do this in production and rely on secret manager to provide secrets
-  GATEWAY_LICENSE_KEY: "<conduktor license>" # Replaced wit h content of LICENSE environment variable
+  GATEWAY_LICENSE_KEY: "<conduktor license>" # This gets replaced with content of LICENSE environment variable
 
   # API admin user :  "admin" / "adminP4ss!"
   GATEWAY_ADMIN_API_USERS: "[{\"username\": \"admin\", \"password\": \"adminP4ss!\", \"admin\": true}]"
@@ -20,27 +20,30 @@ stringData: # use stringData to avoid base64 encoding for demo. Don't do this in
   # random key of 256 bits long encoded in base64 generated with the command "openssl rand -base64 32"
   GATEWAY_USER_POOL_SECRET_KEY: "vrkiI5mKQoVmwcF6y3sg4N+T3NhAIHc7WLUtsHkulhc="
 
-  # Gateway Kafka client truststore password
-  KAFKA_SSL_TRUSTSTORE_PASSWORD: "conduktor"
+  # Gateway Kafka client truststore password if using custom truststore
+  # KAFKA_SSL_TRUSTSTORE_PASSWORD: "conduktor"
 
   # Gateway Kafka client truststore password
 
-  # Gateway Kafka server keystore and key passwords for SSL
-  GATEWAY_SSL_KEY_STORE_PASSWORD: "conduktor"
-  GATEWAY_SSL_KEY_PASSWORD: "conduktor"
+  # Gateway Kafka server keystore and key passwords for SSL if using custom keystore
+  # GATEWAY_SSL_KEY_STORE_PASSWORD: "conduktor"
+  # GATEWAY_SSL_KEY_PASSWORD: "conduktor"
 
   # Gateway kafka mTLS between Application kafka clients and Gateway
   # GATEWAY_SSL_TRUST_STORE_PASSWORD: "conduktor"
 
   # Gateway HTTP API
-  # Gateway HTTPS keystore password
-  GATEWAY_HTTPS_KEY_STORE_PASSWORD: "conduktor"
+  # Gateway HTTPS keystore password if using custom keystore
+  # GATEWAY_HTTPS_KEY_STORE_PASSWORD: "conduktor"
 
-  # Gateway http mTLS Keystore/truststore passwords
+  # Gateway http mTLS truststore password
   # GATEWAY_HTTPS_TRUST_STORE_PASSWORD: "conduktor"
 
-  # Need to override JVM truststore to reach OIDC provider
+  # Need to override JVM truststore to reach OIDC provider.
+  # Points at the cert-manager-generated truststore, which trusts local-selfsigned-ca and
+  # therefore every TLS endpoint in the stack (Kafka, Keycloak, Schema Registry, MinIO, Postgres).
+  # Password must match the gateway-tls-password secret below.
   JAVA_TOOL_OPTIONS: >-
-    -Djavax.net.ssl.trustStore=/etc/conduktor/tls/truststore/truststore.jks
+    -Djavax.net.ssl.trustStore=/etc/gateway/tls/truststore.jks
     -Djavax.net.ssl.trustStorePassword=conduktor
     -Djavax.net.ssl.trustStoreType=JKS

--- a/local-stack/gateway-secrets.yaml
+++ b/local-stack/gateway-secrets.yaml
@@ -42,7 +42,6 @@ stringData: # use stringData to avoid base64 encoding for demo. Don't do this in
   # Need to override JVM truststore to reach OIDC provider.
   # Points at the cert-manager-generated truststore, which trusts local-selfsigned-ca and
   # therefore every TLS endpoint in the stack (Kafka, Keycloak, Schema Registry, MinIO, Postgres).
-  # Password must match the gateway-tls-password secret below.
   JAVA_TOOL_OPTIONS: >-
     -Djavax.net.ssl.trustStore=/etc/gateway/tls/truststore.jks
     -Djavax.net.ssl.trustStorePassword=conduktor

--- a/local-stack/gateway-values.yaml
+++ b/local-stack/gateway-values.yaml
@@ -6,6 +6,28 @@ gateway:
       cpu: 500m
       memory: 1Gi
 
+  securityMode: GATEWAY_MANAGED
+  aclEnabled: "true"
+  # Kafka broker id range needed if using SNI routing on the internal listener.
+  # Kubernetes would need to create an internal service for each hostname.
+  # Not actually used here since we use port based routing for the internal listener
+  kafka:
+    brokerIds: ["0-10"]
+
+  listeners:
+    internal:
+      securityProtocol: SASL_SSL
+      routing: port
+      ports:
+        - "9080-9090"
+    external:
+      securityProtocol: SASL_SSL
+      routing: sni
+      advertisedHost: gateway.conduktor.localhost
+      advertisedHostPattern: broker{{physicalCluster}}{{nodeId}}.gateway.conduktor.localhost
+      bootstrapHostPattern: "gateway.conduktor.localhost"
+      ports:
+        - "9092"
   secretRef: "gateway-secrets"
   env:
     # # Gateway server general configuration
@@ -22,23 +44,6 @@ gateway:
     KAFKA_SECURITY_PROTOCOL: "SASL_SSL"
     KAFKA_SASL_MECHANISM: "PLAIN"
 
-    # Truststore for Gateway kafka client -> Kafka brokers
-    KAFKA_SSL_TRUSTSTORE_LOCATION: /etc/conduktor/tls/truststore/truststore.jks
-    KAFKA_SSL_TRUSTSTORE_TYPE: "JKS"
-
-    #### Gateway Kafka proxy configuration for clients
-    ##
-    GATEWAY_ADVERTISED_HOST: "gateway.conduktor.localhost" # external hostname of the gateway
-
-    # SNI routing configuration
-    GATEWAY_ROUTING_MECHANISM: host
-    GATEWAY_ADVERTISED_SNI_PORT: "9092"
-    GATEWAY_SNI_HOST_SEPARATOR: "." # e.g. "brokermain0" + "." + "gateway.conduktor.localhost"
-    GATEWAY_FEATURE_FLAGS_INTERNAL_LOAD_BALANCING: "false" # https://docs.conduktor.io/gateway/reference/load-balancing/#external-load-balancing
-
-    GATEWAY_SECURITY_MODE: "GATEWAY_MANAGED" # since Gateway 3.10.0
-    GATEWAY_SECURITY_PROTOCOL: "SASL_SSL"
-    GATEWAY_ACL_ENABLED: "true"
     # console-sa/client-sa will connect over SASL/PLAIN and app-1 will connect over OIDC
     GATEWAY_SUPER_USERS: "console-sa;client-sa;app-1"
     GATEWAY_OAUTH_JWKS_URL: "https://keycloak.cdk-deps.svc.cluster.local/realms/conduktor-realm/protocol/openid-connect/certs"
@@ -46,34 +51,6 @@ gateway:
     GATEWAY_OAUTH_EXPECTED_AUDIENCES: "[account]"
     GATEWAY_OAUTH_SUB_CLAIM_NAME: "azp"
 
-    # # Keystore for Gateway TLS certificate
-    # GATEWAY_SSL_KEY_STORE_PATH: "/etc/gateway/tls/keystore.jks" # set by tls.enable
-    GATEWAY_SSL_KEY_TYPE: "JKS"
-
-    # # Truststore for mTLS authentication of Gateway clients
-    # GATEWAY_SSL_TRUST_STORE_PATH: /etc/conduktor/tls/truststore/truststore.jks
-
-    # # Gateway HTTP API
-    # # Gateway HTTPS configuration. Uncomment if you want to use TLS passthrough
-    GATEWAY_HTTPS_KEY_STORE_PATH: "/etc/gateway/tls/keystore.jks"
-    # # Truststore for mTLS authentication of Gateway clients
-    # GATEWAY_HTTPS_TRUST_STORE_PATH: "/etc/conduktor/tls/truststore/truststore.jks"
-
-  volumes:
-    # Mount truststore secrets for kafka and http client
-    - name: truststore
-      secret:
-        secretName: bundle-truststore # secret with truststore.jks containing kafka and schema registry certificates
-
-  volumeMounts:
-    # Mount truststore secrets for kafka and http client
-    - name: truststore
-      mountPath: /etc/conduktor/tls/truststore
-      readOnly: true
-
-  portRange:
-    start: 9092
-    count: 1
   admin:
     port: 8888
     securedMetrics: false
@@ -84,12 +61,25 @@ service:
     type: LoadBalancer
     admin: true
 
-# Mount keystore for TLS
 tls:
-  enable: true
-  secretRef: "gateway-tls-secret"
-  keystoreKey: keystore.jks
-  keystoreFile: keystore.jks
+  keystore:
+    passwordSecretRef:
+      name: conduktor-gateway-jks-password-secret    # Defined in k3d-stack/02-infra-crds.yaml.
+      key: password
+  certManager:                        # Using cert-manager to automate keystore and truststore management
+    enabled: true                     # If using a custom keystore, you must set tls.keystore properties (see documentation)
+    issuerRef:
+      name: local-ca-issuer
+      kind: ClusterIssuer
+    duration: "2160h"                 # Certificate validity (default 90 days)
+    renewBefore: "360h"               # Renew 15 days before expiry
+    sslContextRefreshMinutes: 5       # How often Gateway polls the keystore for updates
+    truststore:                       # Uses same root CA as Kafka. If Kafka used a separate private root CA, you would
+      enabled: true                   # instead set tls.truststore properties (see documentation)
+    httpsAdminApi:
+      enabled: true
+  truststore:
+    keystoreFile: "truststore.jks"
 
 metrics:
   prometheus:
@@ -104,7 +94,10 @@ metrics:
       prometheus: prometheus
       loki: loki
 
-# Expose admin REST API through an ingress
+# Expose the admin REST API through an ingress so it is reachable from the host at
+# https://gateway.conduktor.localhost (README step "Conduktor Gateway").
+# k3d only maps host ports 80, 443 and 9092 to the cluster, so the admin port (8888) is not
+# reachable directly - it has to come in via ingress-nginx on 443.
 ingress:
   enabled: true
   ingressClassName: nginx
@@ -113,6 +106,6 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: local-ca-issuer
     kubernetes.io/ingress.class: nginx
-    # redirect TLS traffic directly to the Gateway container to handle TLS handshake
+    # The admin API serves HTTPS (tls.certManager.httpsAdminApi), so nginx must speak TLS to it
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"

--- a/local-stack/k3d-stack/02-infra-crds.yaml
+++ b/local-stack/k3d-stack/02-infra-crds.yaml
@@ -33,6 +33,28 @@ spec:
   ca:
     secretName: root-ca-secret
 ---
+apiVersion: trust.cert-manager.io/v1alpha1
+kind: Bundle
+metadata:
+  name: bundle-truststore
+spec:
+  sources:
+    - secret:
+        name: root-ca-secret
+        key: ca.crt
+  target:
+    secret:
+      key: ca-bundle.pem
+    additionalFormats:
+      jks:
+        key: truststore.jks
+        # Must match the password expected by consumers: CDK_SSL_TRUSTSTORE_* in console-values.yaml
+        # and ssl.truststore.password in client.properties.
+        password: conduktor
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: conduktor
+---
 #### Components certificates
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -183,6 +205,13 @@ spec:
         name: conduktor-console-jks-password-secret
         key: password
 ---
+# Password cert-manager uses to encrypt the Gateway's generated JKS keystore/truststore.
+# Pinned to a known value so gateway-secrets.yaml's JAVA_TOOL_OPTIONS can reference it.
+# Consumed via tls.keystore.passwordSecretRef in gateway-values.yaml.
+#
+# NOTE: the Gateway Certificate itself is no longer declared here - the gateway chart creates it
+# (as "conduktor-gateway-tls") when tls.certManager.enabled is set, deriving its SANs from the
+# listener configuration. Only this password secret needs to exist beforehand.
 apiVersion: v1
 kind: Secret
 metadata:
@@ -191,38 +220,4 @@ metadata:
 type: Opaque
 stringData:
   password: "conduktor"
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: gateway-tls
-  namespace: conduktor
-spec:
-  isCA: false
-  secretName: gateway-tls-secret
-  subject:
-    organizations:
-      - conduktor
-  commonName: gateway.conduktor.localhost
-  dnsNames:
-    - gateway.conduktor.localhost
-    - "*.gateway.conduktor.localhost"
-    - conduktor-gateway-internal.conduktor.svc.cluster.local
-    - "*.conduktor-gateway-internal.conduktor.svc.cluster.local"
-    - conduktor-gateway-external.conduktor.svc.cluster.local
-    - "*.conduktor-gateway-external.conduktor.svc.cluster.local"
-  issuerRef:
-    name: local-ca-issuer
-    kind: ClusterIssuer
-    group: cert-manager.io
-  privateKey:
-    algorithm: RSA
-    encoding: PKCS1
-    size: 2048
-  keystores:
-    jks:
-      create: true
-      passwordSecretRef:
-        name: conduktor-gateway-jks-password-secret
-        key: password
 ---

--- a/local-stack/k3d-stack/05-coredns-custom.yaml
+++ b/local-stack/k3d-stack/05-coredns-custom.yaml
@@ -5,8 +5,11 @@ metadata:
   namespace: kube-system
 data:
   rewrite.override: |
-    # Add rewrite rules for Conduktor Gateway SNI routing on subdomain per broker instance that redirect to the external service
-    rewrite name regex .*gateway\.conduktor\.localhost conduktor-gateway-external.conduktor.svc.cluster.local answer auto
-    
+    # NOTE: a rewrite for *.gateway.conduktor.localhost used to live here so that in-cluster clients
+    # (Console) could reach the Gateway through its external SNI listener. It is no longer needed:
+    # the Gateway now exposes a dedicated internal listener with port-based routing, so Console talks
+    # to conduktor-gateway-internal.conduktor.svc.cluster.local directly by its real service name.
+    # gateway.conduktor.localhost is now only resolved on the host, via /etc/hosts (see README).
+
     # Add rewrite rule to allow Keycloak OIDC ingress to be resolved by the internal DNS for Console
     rewrite name regex oidc\.localhost keycloak.cdk-deps.svc.cluster.local answer auto

--- a/local-stack/kubernetes_utils.sh
+++ b/local-stack/kubernetes_utils.sh
@@ -143,59 +143,11 @@ generate_schema_registry_jks_truststore() {
   rm -rf "${temp_dir:?Missing temp dir}"
 }
 
-generate_jks_truststore() {
-  local jks_password="conduktor"
-
-  # Temporary directory to store the certificates and JKS file
-  temp_dir=$(mktemp -d)
-  echo "Temporary directory created at $temp_dir"
-
-  echo "Retrieving certificates..."
-  # Retrieve the CA
-  waitSecretCreated cert-manager root-ca-secret
-  kubectl get secret root-ca-secret -n cert-manager -o jsonpath="{.data['ca\.crt']}" | base64 --decode > "$temp_dir/root.ca.crt"
-
-  # Retrieve Postgresql TLS secret
-  waitSecretCreated cdk-deps pg-main-crt-secret
-  waitSecretCreated cdk-deps pg-sql-crt-secret
-  kubectl get secret pg-main-crt-secret -n cdk-deps -o jsonpath="{.data['tls\.crt']}" | base64 --decode > "$temp_dir/main-postgresql.tls.crt"
-  kubectl get secret pg-sql-crt-secret  -n cdk-deps -o jsonpath="{.data['tls\.crt']}" | base64 --decode > "$temp_dir/sql-postgresql.tls.crt"
-
-  # Retrieve the Kafka TLS secret
-  waitSecretCreated cdk-deps kafka-tls
-  kubectl get secret kafka-tls -n cdk-deps -o jsonpath="{.data['tls\.crt']}" | base64 --decode > "$temp_dir/kafka.tls.crt"
-
-  # Retrieve the Schema Registry TLS secret
-  waitSecretCreated cdk-deps sr-crt-secret
-  kubectl get secret sr-crt-secret -n cdk-deps -o jsonpath="{.data['tls\.crt']}" | base64 --decode > "$temp_dir/sr.tls.crt"
-
-  # Retrieve the S3 TLS secret
-  waitSecretCreated cdk-deps s3-crt-secret
-  kubectl get secret s3-crt-secret -n cdk-deps -o jsonpath="{.data['tls\.crt']}" | base64 --decode > "$temp_dir/s3.tls.crt"
-
-  # Retrieve the OIDC TLS secret
-  kubectl get secret keycloak-crt-secret -n cdk-deps -o jsonpath="{.data['tls\.crt']}" | base64 --decode > "$temp_dir/oidc.tls.crt"
-
-  echo "Certificates retrieved successfully."
-  ls -al "$temp_dir"
-  echo "Creating JKS truststore..."
-  # Generate the JKS truststore
-  for cert in "$temp_dir"/*.crt; do
-    keytool -importcert -noprompt \
-      -alias "$(basename "$cert" .crt)" \
-      -file "$cert" \
-      -keystore "$temp_dir/truststore.jks" \
-      -storepass "$jks_password" -noprompt
-  done
-
-  kubectl delete secret bundle-truststore -n conduktor --ignore-not-found
-  kubectl create secret generic bundle-truststore \
-    --from-file=truststore.jks="$temp_dir/truststore.jks" \
-    -n conduktor
-
-  # Clean up
-  rm -rf "${temp_dir:?Missing temp dir}"
-}
+# NOTE: generate_jks_truststore() used to build the "bundle-truststore" secret here by pinning the
+# root CA plus each component's leaf certificate. It has been replaced by the trust-manager Bundle in
+# k3d-stack/02-infra-crds.yaml, which distributes the root CA alone. Every endpoint in the stack is
+# issued by local-ca-issuer and presents its full chain, so the root is sufficient - and unlike the
+# pinned leaves, it does not go stale when certificates are renewed.
 
 # Allows to call a function based on arguments passed to the script
 $*

--- a/local-stack/provisioning/main.tf
+++ b/local-stack/provisioning/main.tf
@@ -3,8 +3,8 @@ resource "conduktor_console_group_v2" "admin" {
   provider = conduktor.console
   name     = "admin"
   spec = {
-    display_name = "admin"
-    description  = "Built-in group with admin level access"
+    display_name    = "admin"
+    description     = "Built-in group with admin level access"
     external_groups = ["conduktor-admin"]
     # Adding external group for admin access for SSO admin user with external group mapping
     members : [var.console_admin_user]
@@ -19,7 +19,7 @@ module "iam" {
   source = "./modules/01-iam"
 
   # input variables
-  users = yamldecode(file("./data/users.yaml"))
+  users  = yamldecode(file("./data/users.yaml"))
   groups = yamldecode(file("./data/groups.yaml"))
 
   # provider configuration
@@ -32,7 +32,7 @@ module "gw-service-accounts" {
   source = "./modules/02-gw-service-accounts"
 
   # input variables
-  service_account_names = ["console-sa", "client-sa"]
+  service_account_names  = ["console-sa", "client-sa"]
   token_lifetime_seconds = var.gateway_token_lifetime_seconds
 
   # provider configuration
@@ -63,7 +63,7 @@ module "clusters" {
         password = var.schema_registry_password
       }
       gateway = {
-        baseUrl       = "${var.gateway_base_url}:8888"
+        baseUrl       = var.gateway_internal_base_url
         adminUser     = var.gateway_admin_user
         adminPassword = var.gateway_admin_password
       }
@@ -85,7 +85,7 @@ module "clusters" {
         password = var.schema_registry_password
       }
       gateway = {
-        baseUrl       = "${var.gateway_base_url}:8888"
+        baseUrl       = var.gateway_internal_base_url
         adminUser     = var.gateway_admin_user
         adminPassword = var.gateway_admin_password
       }
@@ -184,9 +184,9 @@ module "self-service-central" {
 # Self-Service Teams for Website Analytics and E-commerce
 ###
 locals {
-  web_analytics_team = module.iam.group_list["website-analytics-team"]
-  web_analytics_applications = { for app in module.self-service-central.applications: app.name => app if app.spec.owner == local.web_analytics_team.name }
-  web_analytics_applications_instances = { for inst in module.self-service-central.applications_instances: inst.name => inst if contains(keys(local.web_analytics_applications), inst.application ) }
+  web_analytics_team                   = module.iam.group_list["website-analytics-team"]
+  web_analytics_applications           = { for app in module.self-service-central.applications : app.name => app if app.spec.owner == local.web_analytics_team.name }
+  web_analytics_applications_instances = { for inst in module.self-service-central.applications_instances : inst.name => inst if contains(keys(local.web_analytics_applications), inst.application) }
 }
 
 module "self-service-team-website-analytics" {
@@ -196,7 +196,7 @@ module "self-service-team-website-analytics" {
   owner                 = local.web_analytics_team.name
   applications          = local.web_analytics_applications
   application_instances = local.web_analytics_applications_instances
-  permissions = []
+  permissions           = []
   groups = [
     {
       name                 = "website-analytics-dev-support"
@@ -204,7 +204,7 @@ module "self-service-team-website-analytics" {
       description          = "Group for Support Team on Website Analytics Dev instance"
       application          = local.web_analytics_applications["website-analytics"].name
       application_instance = local.web_analytics_applications_instances["website-analytics-dev"].name
-      members = [module.iam.users_list["alice@company.io"].name]
+      members              = [module.iam.users_list["alice@company.io"].name]
     }
   ]
 
@@ -250,9 +250,9 @@ module "self-service-team-website-analytics" {
 }
 
 locals {
-  ecommerce_team = module.iam.group_list["ecommerce-team"]
-  ecommerce_applications = { for app in module.self-service-central.applications: app.name => app if app.spec.owner == local.ecommerce_team.name }
-  ecommerce_applications_instances = { for inst in module.self-service-central.applications_instances: inst.name => inst if contains(keys(local.ecommerce_applications), inst.application ) }
+  ecommerce_team                   = module.iam.group_list["ecommerce-team"]
+  ecommerce_applications           = { for app in module.self-service-central.applications : app.name => app if app.spec.owner == local.ecommerce_team.name }
+  ecommerce_applications_instances = { for inst in module.self-service-central.applications_instances : inst.name => inst if contains(keys(local.ecommerce_applications), inst.application) }
 }
 
 module "self-service-team-ecommerce" {
@@ -283,7 +283,7 @@ module "self-service-team-ecommerce" {
       description          = "Group for Support Team on E-commerce Event dev instance"
       application          = local.ecommerce_applications["ecommerce-sales"].name
       application_instance = local.ecommerce_applications_instances["ecommerce-event-dev"].name
-      members = [module.iam.users_list["alice@company.io"].name]
+      members              = [module.iam.users_list["alice@company.io"].name]
     }
   ]
 

--- a/local-stack/provisioning/providers.tf
+++ b/local-stack/provisioning/providers.tf
@@ -19,7 +19,7 @@ provider "conduktor" {
 provider "conduktor" {
   alias          = "gateway"
   mode           = "gateway"
-  base_url       = var.gateway_base_url
+  base_url       = var.gateway_external_base_url
   admin_user     = var.gateway_admin_user
   admin_password = var.gateway_admin_password
   insecure       = true

--- a/local-stack/provisioning/terraform.tfvars
+++ b/local-stack/provisioning/terraform.tfvars
@@ -4,11 +4,20 @@ console_base_url       = "https://console.conduktor.localhost"
 console_admin_user     = "admin@demo.dev"
 console_admin_password = "adminP4ss!"
 
-gateway_base_url       = "https://gateway.conduktor.localhost"
+# Gateway admin API, as reached from OUTSIDE the cluster: terraform runs on the host, so it goes
+# through the nginx ingress on 443 (gateway.conduktor.localhost is mapped to 127.0.0.1 in /etc/hosts).
+gateway_external_base_url = "https://gateway.conduktor.localhost"
+
+# Gateway admin API, as reached from INSIDE the cluster. This value is stored in Console's cluster
+# configuration and resolved by Console, not by terraform, so it uses the internal service name and
+# the admin-http port directly.
+gateway_internal_base_url = "https://conduktor-gateway-internal.conduktor.svc.cluster.local:8888"
+
 gateway_admin_user     = "admin"
 gateway_admin_password = "adminP4ss!"
 
-bootstrap_servers = "gateway.conduktor.localhost:9092"
+# Console reaches Kafka through the Gateway's internal listener, which uses port-based routing
+bootstrap_servers = "conduktor-gateway-internal.conduktor.svc.cluster.local:9080"
 
 gateway_token_lifetime_seconds = 2630000  # 1 month
 
@@ -16,7 +25,9 @@ schema_registry_url      = "https://schemaregistry.cdk-deps.svc.cluster.local:80
 schema_registry_user     = "sc-user"
 schema_registry_password = "sr-password"
 
-gateway_truststore_location = "/etc/conduktor/tls/truststore/truststore.jks"
+# Path to the truststore *inside the Gateway container* - the Gateway uses it to reach Schema
+# Registry. This is the cert-manager-generated truststore mounted by tls.certManager.truststore.
+gateway_truststore_location = "/etc/gateway/tls/truststore.jks"
 gateway_truststore_password = "conduktor"
 
 kafka_password = "kafka-admin-password"

--- a/local-stack/provisioning/variables.tf
+++ b/local-stack/provisioning/variables.tf
@@ -15,8 +15,13 @@ variable "console_admin_password" {
   sensitive   = true
 }
 
-variable "gateway_base_url" {
-  description = "Base URL for the Conduktor Gateway"
+variable "gateway_external_base_url" {
+  description = "Base URL for the Conduktor Gateway admin API as reached from outside the cluster (through the ingress). Used by the Gateway terraform provider, which runs on the host."
+  type        = string
+}
+
+variable "gateway_internal_base_url" {
+  description = "Base URL for the Conduktor Gateway admin API as reached from inside the cluster. Stored in Console's cluster configuration, so it is resolved by Console, not by terraform."
   type        = string
 }
 


### PR DESCRIPTION
Refactors the local stack onto the Gateway chart's multi-listener configuration, and moves TLS from hand-managed keystores to cert-manager.

## 1. Gateway listeners: flat env vars → structured dual listeners

Previously a single listener assembled from raw env vars (`GATEWAY_ADVERTISED_HOST`, `GATEWAY_ROUTING_MECHANISM: host`, `GATEWAY_ADVERTISED_SNI_PORT`, `GATEWAY_SNI_HOST_SEPARATOR`, `GATEWAY_SECURITY_MODE`/`_PROTOCOL`, `GATEWAY_ACL_ENABLED`, `GATEWAY_FEATURE_FLAGS_INTERNAL_LOAD_BALANCING`) plus `gateway.portRange{start: 9092, count: 1}`.

These are now first-class chart values — `gateway.securityMode`, `gateway.aclEnabled`, `gateway.kafka.brokerIds`, and two listeners:

- **internal** — SASL_SSL, `routing: port`, ports 9080–9090 → in-cluster consumers (Console)
- **external** — SASL_SSL, `routing: sni`, `gateway.conduktor.localhost:9092` → clients on the host

## 2. Gateway TLS: hand-managed → cert-manager

- `tls.enable` + `tls.secretRef: gateway-tls-secret` → `tls.certManager.*` (issuer `local-ca-issuer`, 2160h/360h, `sslContextRefreshMinutes`, `truststore.enabled`, `httpsAdminApi.enabled`)
- The hand-written `gateway-tls` Certificate is **deleted** from `02-infra-crds.yaml` — the chart now creates `conduktor-gateway-tls` and derives its SANs from the listener config. Its JKS password Secret stays, wired in via `tls.keystore.passwordSecretRef`
- The `bundle-truststore` volume/volumeMount and `KAFKA_SSL_TRUSTSTORE_*` env vars are gone: the cert-manager truststore anchors on the shared root CA, so it covers upstream Kafka as well
- `JAVA_TOOL_OPTIONS` retargeted to `/etc/gateway/tls/truststore.jks`
- Newly-redundant passwords commented out in `gateway-secrets.yaml` (`KAFKA_SSL_TRUSTSTORE_PASSWORD`, `GATEWAY_SSL_KEY*`, `GATEWAY_HTTPS_KEY_STORE_PASSWORD`) — cert-manager supplies them by `secretKeyRef` instead

## 3. Truststore distribution: bash → trust-manager Bundle

`generate_jks_truststore()` is deleted (−53 lines). It pulled six leaf certificates plus the root CA and `keytool`'d them into a Secret.

Replaced by a trust-manager `Bundle` sourcing `root-ca-secret`'s `ca.crt` and emitting `bundle-truststore` with both `ca-bundle.pem` and `truststore.jks`. Because it trusts the root CA rather than pinning leaves, it no longer goes stale when certificates renew. `01-start.sh` now waits for the Secret instead of building it.

trust-manager was already installed with `secretTargets.enabled` but had no `Bundle` defined — this puts it to use.

## 4. CoreDNS: gateway rewrite dropped

The `.*gateway\.conduktor\.localhost → conduktor-gateway-external` rewrite is removed — the internal listener lets Console reach the Gateway by its real service name. The `oidc.localhost` rewrite is unrelated and stays.

## 5. Terraform: one gateway URL → explicit internal/external

- `gateway_base_url` split into `gateway_external_base_url` (the provider runs on the host, so it goes through the ingress on 443) and `gateway_internal_base_url` (stored in Console's cluster config and resolved in-cluster, on `:8888`)
- `bootstrap_servers`: `gateway.conduktor.localhost:9092` → `conduktor-gateway-internal…:9080`, moving Console off external SNI onto the internal port-routed listener
- `gateway_truststore_location` → `/etc/gateway/tls/truststore.jks` (used by the Gateway → Schema Registry interceptor)
- `terraform fmt` alignment accounts for most of `main.tf`'s diff

## Incidental

- `unset CDK_API_KEY` in `03-init-conduktor-platform.sh`, so a stale key in the environment can't override `admin_user`/`admin_password`
- Dropped `fsGroup: 0` from `platformCortex.containerSecurityContext` — `fsGroup` is pod-level and not valid on a container
- A typo fix and some missing trailing newlines

The `ingress:` block and `service.external` are comment-only diffs; the ingress was already present on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
